### PR TITLE
Add serial to shortcut list for policy

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -107,6 +107,7 @@ parse_device(char *rule_path, char *rule, rule_t *res)
 {
   char **rul, **rul_list;
   char *value;
+  char *serial = NULL;
   char node_path[128];
 
   snprintf(node_path, 128, "%s/%s", rule_path, rule);
@@ -172,6 +173,14 @@ parse_device(char *rule_path, char *rule, rule_t *res)
         value = parse_value(node_path, *rul);
         if (value != NULL) {
           res->dev_deviceid = strtol(value, NULL, 16);
+          g_free(value);
+        }
+      } else if (!strcmp(*rul, NODE_SERIAL)) {
+        value = parse_value(node_path, *rul);
+        if (value != NULL) {
+          serial = malloc(strlen(value) + 1);
+          strcpy(serial,value);
+          res->dev_serial = serial;
           g_free(value);
         }
       } else db_log(DB_LOG_ERR, "Unknown Device attribute %s", *rul);
@@ -383,6 +392,9 @@ db_write_policy(rule_t *rules)
     if (rule->dev_deviceid != 0) {
       snprintf(value, 5, "%04X", rule->dev_deviceid);
       db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_DEVICE_ID, value);
+    }
+    if (rule->dev_serial != NULL) {
+      db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_SERIAL, rule->dev_serial);
     }
     if (rule->vm_uuid != NULL)
       db_write_rule_key(rule->pos, NODE_VM "/" NODE_UUID, rule->vm_uuid);

--- a/src/db.h
+++ b/src/db.h
@@ -54,6 +54,7 @@
 #define NODE_OPTICAL          "optical"
 #define NODE_VENDOR_ID        "vendor_id"
 #define NODE_DEVICE_ID        "device_id"
+#define NODE_SERIAL           "serial"
 #define NODE_SYSATTR          "sysattr"
 #define NODE_PROPERTY         "property"
 #define NODE_VM             "vm"

--- a/src/device.c
+++ b/src/device.c
@@ -75,7 +75,7 @@ device_lookup_by_attributes(int vendorid,
     device = list_entry(pos, device_t, list);
     if (device->vendorid == vendorid &&
         device->deviceid == deviceid &&
-        (serial == NULL || !(strcmp(device->shortname, serial)))) {
+        (serial == NULL || device->serial == NULL || !(strcmp(device->serial, serial)))) {
       return device;
     }
   }
@@ -90,6 +90,7 @@ device_lookup_by_attributes(int vendorid,
  * @param devid The device ID on the bus
  * @param vendorid The device vendor ID
  * @param deviceid The device device ID
+ * @param serial The device serial number (may not be populated on some devices)
  * @param shortname The short description of the device (product name)
  * @param longname The long description of the device (manufacturer)
  * @param sysname The sysfs name of the device
@@ -99,6 +100,7 @@ device_lookup_by_attributes(int vendorid,
 device_t*
 device_add(int  busid, int  devid,
            int  vendorid, int  deviceid,
+           char *serial,
            char *shortname, char *longname,
            char *sysname, struct udev_device *udev)
 {
@@ -119,6 +121,7 @@ device_add(int  busid, int  devid,
   device->devid = devid;
   device->vendorid = vendorid;
   device->deviceid = deviceid;
+  device->serial = serial;
   device->shortname = shortname;
   device->longname = longname;
   device->sysname = sysname;

--- a/src/policy.h
+++ b/src/policy.h
@@ -59,6 +59,7 @@ typedef struct {
   int dev_not_type;      /**< Device forbidden type (none must match) */
   int dev_vendorid;      /**< Device vendorid, or 0 for none */
   int dev_deviceid;      /**< Device deviceid, or 0 for none */
+  char *dev_serial;      /**< Device serial, or NULL for not set */
   char **dev_sysattrs;   /**< List of key value pairs for the udev sysattrs */
   char **dev_properties; /**< List of key value pairs for the udev properties */
   char *vm_uuid;         /**< VM UUID */

--- a/src/project.h
+++ b/src/project.h
@@ -128,6 +128,7 @@ typedef struct {
   int devid;                /**< Device ID on the bus */
   int vendorid;             /**< Device vendor ID */
   int deviceid;             /**< Device device ID */
+  char *serial;             /**< Device serial number */
   char *shortname;          /**< Name shown in the UI, usually sysattr["product"] */
   char *longname;           /**< Longer name shown nowhere I know of, usually sysattr["manufacturer"] */
   char *sysname;            /**< Name in sysfs */
@@ -201,7 +202,7 @@ void  udev_fill_devices(void);
 
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);
-device_t* device_add(int busid, int devid, int vendorid, int deviceid,
+device_t* device_add(int busid, int devid, int vendorid, int deviceid, char* serial,
                      char *shortname, char *longname, char *sysname, struct udev_device *udev);
 int       device_del(int  busid, int  devid);
 char*     device_type(unsigned char class, unsigned char subclass,

--- a/src/udev.c
+++ b/src/udev.c
@@ -299,6 +299,7 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
   const char *value;
   int busnum, devnum;
   int vendorid, deviceid;
+  char *serial = NULL;
   char *vendor = NULL;
   char *model;
   char *sysname = NULL;
@@ -417,9 +418,18 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
     strcpy(model, value);
   }
 
+  /* Look for the serial, if present (may not be). We only care about short serial,
+   * as long serial is often otherwise not unique */
+  value = udev_device_get_sysattr_value(dev, "serial");
+  if (value != NULL ) {
+    serial = malloc(strlen(value) + 1);
+    strcpy(serial, value);
+  }
+
   /* Finally add the device */
   device = device_add(busnum, devnum,
                       vendorid, deviceid,
+                      serial,
                       model, vendor,
                       sysname, dev);
   if (device == NULL)


### PR DESCRIPTION
Depends on https://github.com/OpenXT/vusb-daemon/pull/2

Will rebase when appropriate and dependency merged (assuming a merge commit will get shoved in the middle). Until then, can start some reviews at least.

Device serial numbers are otherwise only accessible via sysfs/udev property matches. With vendor/device IDs, having serial number as a shortcut makes it easier to lock particular devices (that supply a serial number) to individual VMs.
