### PR TITLE
policy: add a new rule command: default

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -237,6 +237,8 @@ parse_rule(char *rule_node)
         if (value != NULL) {
           if (!strcmp(value, "always"))
             res->cmd = ALWAYS;
+          else if (!strcmp(value, "default"))
+            res->cmd = DEFAULT;
           else if (!strcmp(value, "allow"))
             res->cmd = ALLOW;
           else if (!strcmp(value, "deny"))
@@ -360,6 +362,8 @@ db_write_policy(rule_t *rules)
     if (rule->cmd == ALWAYS)
       db_write_rule_key(rule->pos, NODE_COMMAND, "always");
     else if (rule->cmd == ALLOW)
+      db_write_rule_key(rule->pos, NODE_COMMAND, "default");
+    else if (rule->cmd == DEFAULT)
       db_write_rule_key(rule->pos, NODE_COMMAND, "allow");
     else if (rule->cmd == DENY)
       db_write_rule_key(rule->pos, NODE_COMMAND, "deny");

--- a/src/policy.h
+++ b/src/policy.h
@@ -35,6 +35,7 @@
  */
 enum command {
   ALWAYS,                 /**< Always plug device to VM. implies ALLOW */
+  DEFAULT,                /**< Plug device to VM by default, implies ALLOW */
   ALLOW,                  /**< Allow device to be plugged to VM */
   DENY                    /**< Deny device to be plugged to VM */
 };

--- a/src/vm.c
+++ b/src/vm.c
@@ -64,6 +64,9 @@ vm_lookup_by_uuid(const char *uuid)
   struct list_head *pos;
   vm_t *vm = NULL;
 
+  if (uuid == NULL)
+    return NULL;
+
   list_for_each(pos, &vms.list) {
     vm = list_entry(pos, vm_t, list);
     if (!strcmp(vm->uuid, uuid)) {


### PR DESCRIPTION
"default" auto-assigns devices to VMs but lets the user re-assign them

OXT-583

Signed-off-by: Jed lejosnej@ainfosec.com
