### PR TITLE
OXT-925: Add "nic" and "bluetooth" device types

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ INCLUDES = @DBUS_CFLAGS@ @DBUS_GLIB_CFLAGS@ @LIBXCDBUS_INC@ @LIBV4V_INC@ @LIBUSB
 
 sbin_PROGRAMS = vusb-daemon
 
-PROTO_SRCS = main.c usbowls.c rpc.c udev.c device.c vm.c xenstore.c policy.c db.c usbmanager.c
+PROTO_SRCS = main.c usbowls.c rpc.c udev.c device.c vm.c xenstore.c policy.c db.c usbmanager.c libusb.c
 
 vusb_daemon_SOURCES = ${PROTO_SRCS} rpcgen/ctxusb_daemon_server_obj.c
 

--- a/src/classes.h
+++ b/src/classes.h
@@ -201,3 +201,13 @@ static const class_t classes[] = {
       {0,NULL,NULL} } },
   {0,NULL,NULL}
 };
+
+/* This is a partial list of classes, interfaces, and protocols used for device type filtering */
+
+#define COMMUNICATIONS_CLASS            0x02
+#define WIRELESS_CLASS                  0xE0
+#define VENDOR_SPECIFIC_CLASS           0xFF
+#define ETHERNET_NETWORKING_SUBCLASS    0x06
+#define RADIO_FREQUENCY_SUBCLASS        0x01
+#define BLUETOOTH_PROTOCOL              0x01
+

--- a/src/db.c
+++ b/src/db.c
@@ -136,6 +136,24 @@ parse_device(char *rule_path, char *rule, rule_t *res)
             res->dev_type |= KEYBOARD;
           g_free(value);
         }
+      } else if (!strcmp(*rul, NODE_NIC)) {
+        value = parse_value(node_path, *rul);
+        if (value != NULL) {
+          if (*value == '0')
+            res->dev_not_type |= NIC;
+          else
+            res->dev_type |= NIC;
+          g_free(value);
+        }
+      } else if (!strcmp(*rul, NODE_BLUETOOTH)) {
+        value = parse_value(node_path, *rul);
+        if (value != NULL) {
+          if (*value == '0')
+            res->dev_not_type |= BLUETOOTH;
+          else
+            res->dev_type |= BLUETOOTH;
+          g_free(value);
+        }
       } else if (!strcmp(*rul, NODE_GAME_CONTROLLER)) {
         value = parse_value(node_path, *rul);
         if (value != NULL) {
@@ -378,6 +396,12 @@ db_write_policy(rule_t *rules)
         db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_MASS_STORAGE, "1");
       if (rule->dev_type & OPTICAL)
         db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_OPTICAL, "1");
+      if (rule->dev_type & NIC)
+        db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_NIC, "1");
+      if (rule->dev_type & BLUETOOTH)
+        db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_BLUETOOTH, "1");
+
+ 
     }
     if (rule->dev_not_type != 0) {
       if (rule->dev_not_type & KEYBOARD)
@@ -388,6 +412,11 @@ db_write_policy(rule_t *rules)
         db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_GAME_CONTROLLER, "0");
       if (rule->dev_not_type & MASS_STORAGE)
         db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_MASS_STORAGE, "0");
+      if (rule->dev_not_type & NIC)
+        db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_NIC, "0");
+      if (rule->dev_not_type & BLUETOOTH)
+        db_write_rule_key(rule->pos, NODE_DEVICE "/" NODE_BLUETOOTH, "0");
+
     }
     if (rule->dev_vendorid != 0) {
       snprintf(value, 5, "%04X", rule->dev_vendorid);

--- a/src/db.h
+++ b/src/db.h
@@ -52,6 +52,8 @@
 #define NODE_GAME_CONTROLLER  "game_controller"
 #define NODE_MASS_STORAGE     "mass_storage"
 #define NODE_OPTICAL          "optical"
+#define NODE_NIC              "nic"
+#define NODE_BLUETOOTH        "bluetooth"
 #define NODE_VENDOR_ID        "vendor_id"
 #define NODE_DEVICE_ID        "device_id"
 #define NODE_SERIAL           "serial"

--- a/src/libusb.c
+++ b/src/libusb.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017 Assured Information Security, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/**
+ * @file   libusb.c
+ * @author Troy Crosley <crosleyt@ainfosec.com>
+ * @date   Fri Feb 03 10:53:45 2017
+ *
+ * @brief  libusb interaction
+ *
+ * Functions that usb libusb to find more about the device type
+ */
+
+#include "project.h"
+
+#define BMATTRIBUTES_BULK               0x02
+#define BENDPOINTADDRESS_IN             0x80
+#define TYPICAL_NIC_PACKET_SIZE         0x0200
+#define MAX_ENDPOINTS                   1000
+
+static bool
+libusb_is_ethernet_interface(struct usb_interface_descriptor *interface)
+{
+  return (interface->bInterfaceClass == COMMUNICATIONS_CLASS &&
+    interface->bInterfaceSubClass == ETHERNET_NETWORKING_SUBCLASS);
+}
+
+static bool
+libusb_is_wireless_interface(struct usb_interface_descriptor *interface)
+{
+  return (interface->bInterfaceClass == WIRELESS_CLASS &&
+    (interface->bInterfaceSubClass != RADIO_FREQUENCY_SUBCLASS ||
+    interface->bInterfaceProtocol != BLUETOOTH_PROTOCOL));
+}
+
+static bool
+libusb_is_bluetooth_interface(struct usb_interface_descriptor *interface)
+{
+  return (interface->bInterfaceClass == WIRELESS_CLASS &&
+    interface->bInterfaceSubClass == RADIO_FREQUENCY_SUBCLASS &&
+    interface->bInterfaceProtocol == BLUETOOTH_PROTOCOL);
+}
+
+/**
+ * Identify vendor-specific interfaces with endpoints that support
+ * bulk data transfers both in and out with a packet size of at least
+ * TYPICAL_NIC_PACKET_SIZE (512). Though all the USB NICs that were
+ * tested had such an endpoint and none of the other USB devices did,
+ * It is possible that checking for NICs in this manner will result
+ * in false positives or negatives.
+ */
+static bool
+libusb_is_unknown_bulk_transfer_interface(struct usb_interface_descriptor *interface)
+{
+  int i;
+  bool has_bulk_in = false;
+  bool has_bulk_out = false;
+
+  if (interface->bInterfaceClass == VENDOR_SPECIFIC_CLASS)
+    for (i = 0; i < interface->bNumEndpoints; i++)
+    {
+      struct usb_endpoint_descriptor *endpoint = &interface->endpoint[i];
+
+      if (endpoint->bmAttributes == BMATTRIBUTES_BULK && endpoint->wMaxPacketSize >= TYPICAL_NIC_PACKET_SIZE)
+      {
+        if (endpoint->bEndpointAddress & BENDPOINTADDRESS_IN)
+          has_bulk_in = true;
+        else
+          has_bulk_out = true;
+        if (has_bulk_in && has_bulk_out)
+          return true;
+      }
+    }
+  return false;
+}
+
+static struct usb_device *
+libusb_findDevice(int vendorid, int productid)
+{
+  struct usb_bus *bus;
+  struct usb_device *dev;
+  struct usb_bus *busses;
+
+  usb_find_busses();
+  usb_find_devices();
+  busses = usb_get_busses();
+
+  for (bus = busses; bus; bus = bus->next)
+    for (dev = bus->devices; dev; dev = dev->next)
+      if ((dev->descriptor.idVendor == vendorid) && (dev->descriptor.idProduct == productid))
+        return dev;
+
+  return NULL;
+}
+
+/**
+ * Determine if the device is a possible NIC or Bluetooth device.
+ * It parses the USB descriptors, which can have multiple
+ * configurations, which can have multiple interfaces, which can have
+ * multiple "altSettings," which can have multiple endpoints.
+ */
+void
+libusb_find_more_about_nic(device_t *device)
+{
+  int i, j, k;
+  int totalEndpoints = 0;
+  struct usb_device *libusb_device = libusb_findDevice(device->vendorid, device->deviceid);	
+
+  for (i = 0; i < libusb_device->descriptor.bNumConfigurations; i++)
+  {
+    struct usb_config_descriptor *config = &libusb_device->config[i];
+
+    for(j = 0; j < config->bNumInterfaces; j++)
+    {
+      struct usb_interface *interface = &config->interface[j];
+
+      for (k = 0; k < interface->num_altsetting; k++)
+      {
+        struct usb_interface_descriptor *interface_descriptor = &interface->altsetting[k];
+
+        /* This is just an arbitrary loop limit to make the nested for-loops less scary */
+        totalEndpoints++;
+        if (totalEndpoints > MAX_ENDPOINTS)
+        {
+          xd_log(LOG_WARN, "Aborting libusb_find_more_about_nic due to exceeding the endpoint limit");
+          return;
+        }
+
+        if (libusb_is_unknown_bulk_transfer_interface(interface_descriptor) ||
+            libusb_is_ethernet_interface(interface_descriptor) ||
+            libusb_is_wireless_interface(interface_descriptor))
+          device->type |= NIC;
+        if (libusb_is_bluetooth_interface(interface_descriptor))
+          device->type |= BLUETOOTH;
+      }
+    }
+  }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,9 @@ main() {
   int nfds;
   int udevfd;
 
+  /* init libusb */
+  usb_init();
+
   /* Init global VMs and devices lists */
   INIT_LIST_HEAD(&vms.list);
   INIT_LIST_HEAD(&devices.list);

--- a/src/policy.h
+++ b/src/policy.h
@@ -45,6 +45,8 @@ enum command {
 #define GAME_CONTROLLER 0x4     /**< Game controller device type */
 #define MASS_STORAGE    0x8     /**< Mass storage device type */
 #define OPTICAL         0x10    /**< Optical (cd-rom) device type */
+#define NIC             0x20	/**< Possible NIC device type */
+#define BLUETOOTH       0x40	/**< Bluetooth device type */
 
 /**
  * @brief Policy rule structure

--- a/src/project.h
+++ b/src/project.h
@@ -177,6 +177,8 @@ int   udev_init(void);
 void  udev_event(void);
 void  udev_fill_devices(void);
 
+void  libusb_find_more_about_nic(device_t *device);
+
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);
 device_t* device_add(int busid, int devid, int vendorid, int deviceid, char* serial,

--- a/src/udev.c
+++ b/src/udev.c
@@ -28,6 +28,11 @@
 
 #include "project.h"
 
+#define BMATTRIBUTES_BULK               0x02
+#define BENDPOINTADDRESS_IN             0x80
+#define TYPICAL_NIC_PACKET_SIZE         0x0200
+#define MAX_ENDPOINTS                   1000
+
 /**
  * The global udev monitor handler. Only used in udev.c
  */
@@ -246,6 +251,7 @@ udev_find_more(struct udev_device *dev, device_t *device, int new)
     udev_find_more_about_input(udev_device, device);
     udev_find_more_about_class(udev_device, device);
     udev_find_more_about_optical(udev_device, device, new);
+    libusb_find_more_about_nic(device);
     udev_device_unref(udev_device);
   }
 
@@ -575,6 +581,8 @@ udev_event(void)
         xd_log(LOG_INFO, "   Joystick: %d", !!(device->type & GAME_CONTROLLER));
         xd_log(LOG_INFO, "   MassStorage: %d", !!(device->type & MASS_STORAGE));
         xd_log(LOG_INFO, "   Optical: %d", !!(device->type & OPTICAL));
+        xd_log(LOG_INFO, "   NIC: %d", !!(device->type & NIC));
+        xd_log(LOG_INFO, "   Bluetooth: %d", !!(device->type & BLUETOOTH));
         xd_log(LOG_INFO, "ADDED");
         /* We keep a reference to the udev device, mainly for advanced rule-matching */
         /* udev_device_unref(dev); */


### PR DESCRIPTION
This PR lets vusb filter devices that are NICs (i.e. Ethernet or wireless adapters) or Bluetooth adapters. A lot of USB NICs are designed to be used with custom drivers and don't explicitly tell you that they are NICs, so it has to infer whether they are NICs based on their endpoint descriptors.