### PR TITLE
Use 1 select() call and let it block

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,6 @@ static void fill_vms()
 int
 main() {
   int ret;
-  struct timeval tv;
   fd_set readfds;
   fd_set writefds;
   fd_set exceptfds;
@@ -125,18 +124,13 @@ main() {
     FD_ZERO(&readfds);
     FD_ZERO(&writefds);
     FD_ZERO(&exceptfds);
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000;
-    nfds = xcdbus_pre_select(g_xcbus, 0, &readfds, &writefds, &exceptfds);
-    select(nfds, &readfds, &writefds, &exceptfds, &tv);
-    xcdbus_post_select(g_xcbus, 0, &readfds, &writefds, &exceptfds);
 
-    /* Check udev */
-    FD_ZERO(&readfds);
     FD_SET(udevfd, &readfds);
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000;
-    ret = select(udevfd + 1, &readfds, NULL, NULL, &tv);
+    nfds = udevfd + 1;
+
+    nfds = xcdbus_pre_select(g_xcbus, nfds, &readfds, &writefds, &exceptfds);
+    ret = select(nfds, &readfds, &writefds, &exceptfds, NULL);
+    xcdbus_post_select(g_xcbus, nfds, &readfds, &writefds, &exceptfds);
     if (ret > 0 && FD_ISSET(udevfd, &readfds))
       udev_event();
   }


### PR DESCRIPTION
vusb-daemon spends a lot of time looping since it has two separate
select calls with short timeouts.  Unify the two select calls and let it
block to avoid needless CPU usage.

xcdbus_pre_select is written to add to in-use fd_sets and nfds, so use
that feature.  xcdbus_post_select will loop over its registered watches
checking for if the corresponding FD is set, so an extra FD in readfds
is fine.  udevfd can then be checked for events as is done currently.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
---
I haven't actually tested USB pass through with this change.  Drivers from the ais build server seem to install in Windows, but I don't see a OpenXT USB Controller in device manager.  The other PV drivers are running though.

Looking at strace after the change, the daemon seems to be reacting just fine.