### PR TITLE
Fix warning with recent GCC

### DIFF
--- a/src/udev.c
+++ b/src/udev.c
@@ -357,11 +357,8 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
   value = udev_device_get_sysname(dev);
   if (value == NULL)
     return NULL;
-  else {
-    size = strlen(value) + 1;
-    sysname = malloc(size);
-    strncpy(sysname, value, size);
-  }
+  else
+    sysname = strdup(value);
 
   /* This is a hub, we don't do hubs. */
   if (class == 0x09)


### PR DESCRIPTION
GCC now warns when strncpy uses the size of the source string.
Fixing by using strdup(), which also simplifies the code.

Signed-off-by: Jed <lejosnej@ainfosec.com>