### PR TITLE
Prevent sticky & auto-assign of ambiguous devices

### DIFF
--- a/src/project.h
+++ b/src/project.h
@@ -184,6 +184,7 @@ void  udev_fill_devices(void);
 
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);
+int       device_is_ambiguous(device_t* device);
 device_t* device_add(int busid, int devid, int vendorid, int deviceid, char* serial,
                      char *shortname, char *longname, char *sysname, struct udev_device *udev);
 int       device_del(int  busid, int  devid);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -422,8 +422,15 @@ gboolean ctxusb_daemon_set_sticky(CtxusbDaemonObject *this,
 
   if (IN_sticky == 0)
     policy_unset_sticky(IN_dev_id);
-  else
-    policy_set_sticky(IN_dev_id);
+  else {
+    if (policy_set_sticky(IN_dev_id) == 1){
+      g_set_error(error,
+                DBUS_GERROR,
+                DBUS_GERROR_FAILED,
+                "Device %d is ambiguous, failed to set as sticky", IN_dev_id);
+    return FALSE;
+    }
+  }
 
   return TRUE;
 }


### PR DESCRIPTION
Add checks for device ambiguity to:
- Setting the sticky but
- Automatic assignment of new device
- Automatic assignment of created VM

This prevents policy rules from matching multiple devices, each of which
would be passed to a single VM instance. This is most common when
devices do not populate the serial number, thus there is not enough
information to uniquely identify based on policy rules. This does not
affect manual assignment, which uses USB bus and device IDs as opposed
to the vendor/product IDs of common rules such as the sticky/ALWAYS
mechanism.

OXT-1782

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>