### PR TITLE
Logging improvements to vUSB

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -288,6 +288,15 @@ device_unplug_all_from_vm(int domid)
     device = list_entry(pos, device_t, list);
     if (device->vm != NULL && device->vm->domid == domid) {
       res |= usbowls_unplug_device(domid, device->busid, device->devid);
+      xd_log(LOG_INFO,
+          "Device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] unplugged from VM [UUID=%s, DomID=%d]",
+          device->busid,
+          device->devid,
+          device->vendorid,
+          device->deviceid,
+          device->serial,
+          device->vm->uuid,
+          domid);
       device->vm = NULL;
     }
   }

--- a/src/policy.c
+++ b/src/policy.c
@@ -462,7 +462,7 @@ policy_get_sticky_uuid(int dev)
  * Check if the policy allows a given device to be assigned to a given VM
  */
 bool
-policy_is_allowed(device_t *device, vm_t *vm)
+policy_is_allowed(device_t *device, vm_t *vm, rule_t **rule_ptr)
 {
   struct list_head *pos;
   rule_t *rule;
@@ -483,6 +483,8 @@ policy_is_allowed(device_t *device, vm_t *vm)
             device->serial,
             vm->uuid,
             rule->pos);
+        if (rule_ptr != NULL)
+          *rule_ptr = rule;
         return true;
       }
       else {
@@ -495,6 +497,8 @@ policy_is_allowed(device_t *device, vm_t *vm)
             device->serial,
             vm->uuid,
             rule->pos);
+        if (rule_ptr != NULL)
+          *rule_ptr = rule;
         return false;
       }
     }
@@ -558,7 +562,7 @@ policy_auto_assign_new_device(device_t *device)
   if (vm != NULL &&
       vm->domid > 0 &&
       vm->domid != uivm &&
-      policy_is_allowed(device, vm)) {
+      policy_is_allowed(device, vm, &rule)) {
     device->vm = vm;
     res = usbowls_plug_device(vm->domid, device->busid, device->devid);
     if (res != 0)

--- a/src/policy.c
+++ b/src/policy.c
@@ -388,6 +388,13 @@ policy_set_sticky(int dev)
       new_rule->pos = rule->pos - 1;
     break;
   }
+  xd_log(LOG_INFO,
+      "Created automatic assignment rule [%d] for device [VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s]",
+      new_rule->pos,
+      device->vendorid,
+      device->deviceid,
+      device->serial,
+      new_rule->vm_uuid);
   list_add(&new_rule->list, &rules.list);
 
   db_write_policy(&rules);
@@ -418,6 +425,7 @@ policy_unset_sticky(int dev)
   if (rule == NULL)
     return -1;
   list_del(&rule->list);
+  xd_log(LOG_INFO, "Policy %d removed", rule->pos);
   policy_free_rule(rule);
   db_write_policy(&rules);
 
@@ -464,10 +472,43 @@ policy_is_allowed(device_t *device, vm_t *vm)
     /* First match wins (or looses), ALWAYS/DEFAULT implies ALLOW */
     if (device_matches_rule(rule, device) &&
         vm_matches_rule(rule, vm))
-      return (rule->cmd != DENY);
+    {
+      if (rule->cmd != DENY) {
+        xd_log(LOG_INFO,
+            "Assignment of device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s], allowed by rule %d",
+            device->busid,
+            device->devid,
+            device->vendorid,
+            device->deviceid,
+            device->serial,
+            vm->uuid,
+            rule->pos);
+        return true;
+      }
+      else {
+        xd_log(LOG_INFO,
+            "Assignment of device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s], denied by rule %d",
+            device->busid,
+            device->devid,
+            device->vendorid,
+            device->deviceid,
+            device->serial,
+            vm->uuid,
+            rule->pos);
+        return false;
+      }
+    }
   }
 
   /* No match found, default to DENY. Return TRUE here to default to ALLOW */
+  xd_log(LOG_INFO,
+    "No rule qualifying assignment of device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s], implicitly denying",
+    device->busid,
+    device->devid,
+    device->vendorid,
+    device->deviceid,
+    device->serial,
+    vm->uuid);
   return false;
 }
 
@@ -522,6 +563,16 @@ policy_auto_assign_new_device(device_t *device)
     res = usbowls_plug_device(vm->domid, device->busid, device->devid);
     if (res != 0)
       device->vm = NULL;
+    xd_log(LOG_INFO,
+        "Automatically assigned device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s, DomID=%d], according to policy rule %d",
+        device->busid,
+        device->devid,
+        device->vendorid,
+        device->deviceid,
+        device->serial,
+        vm->uuid,
+        vm->domid,
+        rule->pos);
   }
 
   return res;
@@ -581,6 +632,16 @@ policy_auto_assign_devices_to_new_vm(vm_t *vm)
           /* No need to check the policy, ALWAYS implies ALLOW */
           device->vm = vm;
           ret |= -usbowls_plug_device(vm->domid, device->busid, device->devid);
+          xd_log(LOG_INFO,
+              "Automatically assigned device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] to VM [UUID=%s, DomID=%d], according to policy rule %d",
+              device->busid,
+              device->devid,
+              device->vendorid,
+              device->deviceid,
+              device->serial,
+              rule->vm_uuid,
+              vm->domid,
+              rule->pos);
         }
       }
     }

--- a/src/project.h
+++ b/src/project.h
@@ -225,7 +225,7 @@ void  policy_add_rule(rule_t *rule);
 void  policy_free_rule(rule_t *rule);
 void  policy_list_rules(uint16_t **list, size_t *size);
 rule_t* policy_get_rule(uint16_t position);
-bool  policy_is_allowed(device_t *device, vm_t *vm);
+bool  policy_is_allowed(device_t *device, vm_t *vm, rule_t **rule_ptr);
 int   policy_set_sticky(int dev);
 int   policy_unset_sticky(int dev);
 char* policy_get_sticky_uuid(int dev);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -707,7 +707,7 @@ gboolean ctxusb_daemon_assign_device(CtxusbDaemonObject *this,
     g_set_error(error,
                 DBUS_GERROR,
                 DBUS_GERROR_FAILED,
-                "The policy denied assignation of device %d to VM %s", IN_dev_id, IN_vm_uuid);
+                "The policy denied assignment of device %d to VM %s", IN_dev_id, IN_vm_uuid);
     return FALSE;
   }
 
@@ -722,6 +722,14 @@ gboolean ctxusb_daemon_assign_device(CtxusbDaemonObject *this,
     return FALSE;
   }
 
+  xd_log(LOG_INFO,
+      "Device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X] plugged into VM [UUID=%s, DomID=%d]",
+      device->busid,
+      device->devid,
+      device->vendorid,
+      device->deviceid,
+      vm->uuid,
+      vm->domid);
   return TRUE;
 }
 
@@ -764,6 +772,15 @@ gboolean ctxusb_daemon_unassign_device(CtxusbDaemonObject *this,
                 "Failed to gracefully unplug device %d-%d from VM %d", device->busid, device->devid, device->vm->domid);
     ret = FALSE;
   }
+  xd_log(LOG_INFO,
+      "Device [Bus=%03d, Dev=%03d, VID=%04X, PID=%04X, Serial=%s] unplugged from VM [UUID=%s, DomID=%d]",
+      device->busid,
+      device->devid,
+      device->vendorid,
+      device->deviceid,
+      device->serial,
+      device->vm->uuid,
+      device->vm->domid);
 
   device->vm = NULL;
 

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -698,7 +698,7 @@ gboolean ctxusb_daemon_assign_device(CtxusbDaemonObject *this,
                 "Device %d is set to be always assigned to another VM", IN_dev_id);
     return FALSE;
   }
-  if (!policy_is_allowed(device, vm)) {
+  if (!policy_is_allowed(device, vm, NULL)) {
     notify_com_citrix_xenclient_usbdaemon_device_rejected(g_xcbus,
 							  USBDAEMON,
 							  USBDAEMON_OBJ,

--- a/src/vm.c
+++ b/src/vm.c
@@ -128,7 +128,7 @@ vm_add(const int domid, const char *uuid)
     }
   }
 
-  xd_log(LOG_INFO, "Adding vm, domid=%d, uuid=%s", domid, new_uuid);
+  xd_log(LOG_DEBUG, "Adding vm, domid=%d, uuid=%s", domid, new_uuid);
   vm = malloc(sizeof(vm_t));
   vm->domid = domid;
   vm->uuid = new_uuid;

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -240,7 +240,7 @@ xenstore_list_domain_devs(dominfo_t *domp)
       char *bepath = xenstore_dev_bepath(domp, "vusb", virtid);
       char *online = xenstore_get_keyval(bepath, "online");
       if (online && !strcmp(online, "1"))
-        xd_log(LOG_INFO, "%d %d", bus, dev);
+        xd_log(LOG_DEBUG, "Device %03d:%03d is online", bus, dev);
       free(online);
       free(bepath);
     }
@@ -467,7 +467,7 @@ xenstore_destroy_usb(dominfo_t *domp, usbinfo_t *usbp)
   char *fepath;
   int ret;
 
-  xd_log(LOG_INFO, "Deleting VUSB node %d for %d.%d",
+  xd_log(LOG_DEBUG, "Deleting VUSB node %d for %d.%d",
          usbp->usb_virtid, usbp->usb_bus, usbp->usb_device);
 
   bepath = xenstore_dev_bepath(domp, "vusb", usbp->usb_virtid);
@@ -485,9 +485,8 @@ xenstore_destroy_usb(dominfo_t *domp, usbinfo_t *usbp)
     xs_rm(xs_handle, XBT_NULL, fepath);
     ret = 0;
   } else {
-    xd_log(LOG_ERR, "Failed to bring the USB device offline");
+    xd_log(LOG_ERR, "Failed to bring the USB device offline, cleaning xenstore nodes anyway");
     /* FIXME: Should we keep the nodes around? Check if the VM is asleep? */
-    xd_log(LOG_ERR, "Cleaning xenstore nodes anyway");
     xs_rm(xs_handle, XBT_NULL, bepath);
     xs_rm(xs_handle, XBT_NULL, fepath);
     ret = -1;


### PR DESCRIPTION
- Add logging to specific desired events
-- Device added
-- Device removed
-- Device assigned to VM
-- Device unassigned from VM
-- Policy rule added
-- Policy rule removed
-- Policy match for decision to allow assignment
-- Policy match for decision to deny assignment
-- Implicit policy deny due to no matching policy rule
- Move some low-level logs to DEBUG priority
- Move some error logs to ERROR priority

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>