### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ depcomp
 install-sh
 missing
 compile
+*~
+oe-logs
+oe-workdir


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A. Up to date gitignore would prevent unecessary rebuilds.