### PR TITLE
vusbd: segfault on uninitialized xenstore

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,12 @@ main() {
   INIT_LIST_HEAD(&vms.list);
   INIT_LIST_HEAD(&devices.list);
 
+  /* Initialize xenstore handle in usbowls */
+  xs_handle = NULL;
+  ret = xenstore_init();
+  if (ret != 0)
+    return ret;
+
   /* Setup dbus */
   rpc_init();
 
@@ -88,12 +94,6 @@ main() {
 
   /* Populate the VM list */
   fill_vms();
-
-  /* Initialize xenstore handle in usbowls */
-  xs_handle = NULL;
-  ret = xenstore_init();
-  if (ret != 0)
-    return ret;
 
   /* Why would we do that? */
   /* Disable driver autoprobing */


### PR DESCRIPTION
rpc_init() is called first. It sets up libxcdbus and exports the service object then waits for `com.citrix.xenclient.xenmgr` and
`com.citrix.xenclient.input` to get an owner. Until that happens, if a call to the dbus server object can be triggered, but the xenstore handle is not initialized:

```
3  0x00007f2e0393626c in xs_get_domain_path () at /usr/lib/libxenstore.so.3.0
4  0x00000000004075ea in xenstore_dom_read (domid=domid@entry=1, format=format@entry=0x40b2c6 "vm") at ../../git/src/xenstore.c:118
5  0x000000000040456d in add_vm (domid=1) at ../../git/src/rpc.c:133
6  ctxusb_daemon_new_vm (this=this@entry=0x1c51d00 [CtxusbDaemonObject], IN_dom_id=1, error=0x7fffda7fe950) at ../../git/src/rpc.c:149
7  0x000000000040a6bf in dbus_glib_marshal_ctxusb_daemon_BOOLEAN__INT_POINTER
   (closure=0x7fffda7fea20, return_value=0x7fffda7fe980, n_param_values=<optimized out>, param_values=0x1c52330, invocation_hint=<optimized out>, marshal_data=<optimized out>)
   at rpcgen/ctxusb_daemon_server_marshall.h:430
8  0x00007f2e03afb508 in invoke_object_method
   (message=0x1c53180, connection=0x1c4fb40, method=0x40d880 <dbus_glib_ctxusb_daemon_methods+96>, object_info=<optimized out>, object=<optimized out>)
   at ../../dbus-glib-0.110/dbus/dbus-gobject.c:1906
9  object_registration_message (connection=0x1c4fb40, message=0x1c53180, user_data=<optimized out>) at ../../dbus-glib-0.110/dbus/dbus-gobject.c:2168
10 0x00007f2e03b3e28d in  () at /usr/lib/libdbus-1.so.3
11 0x00007f2e03b2f814 in dbus_connection_dispatch () at /usr/lib/libdbus-1.so.3
12 0x00007f2e0396b0ba in xcdbus_dispatch (xc=0x1c52ea0) at xcdbus.c:564
13 xcdbus_dispatch (xc=xc@entry=0x1c52ea0) at xcdbus.c:533
14 0x0000000000409470 in com_citrix_xenclient_db_list_
   (_service=0x40cb06 "com.citrix.xenclient.db", _obj_path=0x40b020 "/", OUT_value=0x7fffda7fed18, IN_path=0x40caf2 "/usb-rules", _conn=0x1c52ea0) at ./rpcgen/db_client.h:320
15 db_read_policy (rules=rules@entry=0x412080 <rules>) at ../../git/src/db.c:324
16 0x0000000000408e12 in policy_init () at ../../git/src/policy.c:765
17 0x00000000004038f7 in main () at ../../git/src/main.c:83
```

Since Xenstore can be initialized first and does not depend on anything,
just do so.

A reliable way to reproduce this is by starting vusb-daemon first then launch vGlass, since vGlass owns `com.citrix.xenclient.input`