### PR TITLE
usbvm

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -172,6 +172,17 @@ device_add(int  busid, int  devid,
   return device;
 }
 
+void device_free(device_t *device)
+{
+  free(device->shortname);
+  free(device->longname);
+  free(device->sysname);
+  free(device->serial);
+  /* udev_device_unref is okay when udev is NULL */
+  udev_device_unref(device->udev);
+  free(device);
+}
+
 /**
  * Remove a device from the global list of devices
  *
@@ -195,11 +206,7 @@ device_del(int  busid,
   }
   if (device != NULL && device->busid == busid && device->devid == devid) {
     list_del(pos);
-    free(device->shortname);
-    free(device->longname);
-    free(device->sysname);
-    udev_device_unref(device->udev);
-    free(device);
+    device_free(device);
   } else {
     xd_log(LOG_ERR, "Device not found: %d-%d", busid, devid);
     return -1;

--- a/src/device.c
+++ b/src/device.c
@@ -206,6 +206,7 @@ device_del(int  busid,
   }
   if (device != NULL && device->busid == busid && device->devid == devid) {
     list_del(pos);
+    xsdev_del(device);
     device_free(device);
   } else {
     xd_log(LOG_ERR, "Device not found: %d-%d", busid, devid);

--- a/src/device.c
+++ b/src/device.c
@@ -138,6 +138,7 @@ device_is_ambiguous(device_t *device)
 device_t*
 device_add(int  busid, int  devid,
            int  vendorid, int  deviceid,
+           int  type,
            char *serial,
            char *shortname, char *longname,
            char *sysname, struct udev_device *udev)
@@ -165,7 +166,7 @@ device_add(int  busid, int  devid,
   device->sysname = sysname;
   device->udev = udev;
   device->vm = NULL; /* The UI isn't happy if the device is assigned to dom0 */
-  device->type = 0;
+  device->type = type;
   list_add(&device->list, &devices.list);
 
   return device;

--- a/src/main.c
+++ b/src/main.c
@@ -125,6 +125,8 @@ main(int argc, char *argv[]) {
       return -1;
     }
 
+    xenstore_state_handle();
+
     /* Populate the VM list */
     fill_vms();
   }

--- a/src/main.c
+++ b/src/main.c
@@ -84,7 +84,7 @@ void dbus_post_select(int nfds, fd_set *readfds, fd_set *writefds,
 }
 
 int
-main() {
+main(int argc, char *argv[]) {
   int ret;
   fd_set readfds;
   fd_set writefds;
@@ -92,6 +92,7 @@ main() {
   int nfds;
   int xsfd;
   int udevfd;
+  int dbus = 1;
 
   /* init libusb */
   usb_init();
@@ -100,23 +101,33 @@ main() {
   INIT_LIST_HEAD(&vms.list);
   INIT_LIST_HEAD(&devices.list);
 
+  if (argc > 1 && strcmp(argv[1], "stub-mode") == 0) {
+    xd_log(LOG_INFO, "Running in stub-mode (no D-Bus)");
+    dbus = 0;
+    g_xcbus = NULL;
+  } else {
+    xd_log(LOG_INFO, "Running in full mode with D-Bus");
+  }
+
   xs_handle = NULL;
   xsfd = xenstore_init();
   if (xsfd == -1)
     return -1;
 
-  /* Setup dbus */
-  rpc_init();
+  if (dbus) {
+    /* Setup dbus */
+    rpc_init();
 
-  /* Load the policy bits */
-  ret = policy_init();
-  if (ret != 0) {
-    xd_log(LOG_ERR, "Unable to initialize the policy bits");
-    return -1;
+    /* Load the policy bits */
+    ret = policy_init();
+    if (ret != 0) {
+      xd_log(LOG_ERR, "Unable to initialize the policy bits");
+      return -1;
+    }
+
+    /* Populate the VM list */
+    fill_vms();
   }
-
-  /* Populate the VM list */
-  fill_vms();
 
   /* Why would we do that? */
   /* Disable driver autoprobing */
@@ -153,8 +164,8 @@ main() {
     FD_ZERO(&writefds);
     FD_ZERO(&exceptfds);
 
-    FD_SET(xsfd, &readfds);
     FD_SET(udevfd, &readfds);
+    FD_SET(xsfd, &readfds);
     nfds = xsfd > udevfd ? xsfd : udevfd;
     nfds = nfds + 1;
 

--- a/src/main.c
+++ b/src/main.c
@@ -81,9 +81,9 @@ main() {
   INIT_LIST_HEAD(&devices.list);
 
   xs_handle = NULL;
-  ret = xenstore_init();
-  if (ret != 0)
-    return ret;
+  xsfd = xenstore_init();
+  if (xsfd == -1)
+    return -1;
 
   /* Setup dbus */
   rpc_init();
@@ -115,8 +115,8 @@ main() {
   /* Populate the USB device list */
   udev_fill_devices();
 
-  xsfd = xsdev_watch_init();
-  if (xsfd < 0) {
+  ret = xsdev_watch_init();
+  if (ret == 0) {
     xd_log(LOG_ERR, "Unable to initialize xenstore device watch");
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,11 @@ main(int argc, char *argv[]) {
     xd_log(LOG_ERR, "Unable to initialize xenstore device watch");
   }
 
+  ret = xsdev_fill();
+  if (ret == 0) {
+    xd_log(LOG_ERR, "Unable to populate devices from xenstore");
+  }
+
   /* Setup libusb */
   /* if (libusb_init(NULL) != 0) { */
   /*   xd_log(LOG_ERR, "Unable to initialize libusb"); */

--- a/src/main.c
+++ b/src/main.c
@@ -80,7 +80,6 @@ main() {
   INIT_LIST_HEAD(&vms.list);
   INIT_LIST_HEAD(&devices.list);
 
-  /* Initialize xenstore handle in usbowls */
   xs_handle = NULL;
   ret = xenstore_init();
   if (ret != 0)

--- a/src/project.h
+++ b/src/project.h
@@ -174,6 +174,7 @@ vm_t vms;                    /**< The global list of VMs, handled by vm.c */
 device_t devices;            /**< The global list of devices, handled by device.c */
 struct udev *udev_handle;    /**< The global udev handle, initialized by udev_init() */
 extern int usb_backend_domid;
+extern int my_domid;
 
 int   vusb_assign_local(int vendor, int product, int add);
 int   usbowls_plug_device(int domid, int bus, int device);

--- a/src/project.h
+++ b/src/project.h
@@ -235,6 +235,7 @@ int   xenstore_new_backend(const int backend_domid);
 int   xsdev_watch_init(void);
 void  xsdev_watch_deinit(void);
 void  xsdev_write(device_t *dev);
+int   xsdev_fill(void);
 void  xsdev_del(device_t *dev);
 
 char *xasprintf(const char *fmt, ...);

--- a/src/project.h
+++ b/src/project.h
@@ -231,6 +231,7 @@ int   xenstore_new_backend(const int backend_domid);
 int   xsdev_watch_init(void);
 void  xsdev_watch_deinit(void);
 void  xsdev_write(device_t *dev);
+void  xsdev_del(device_t *dev);
 
 int   policy_init(void);
 void  policy_add_rule(rule_t *rule);

--- a/src/project.h
+++ b/src/project.h
@@ -202,6 +202,7 @@ int       device_is_ambiguous(device_t* device);
 device_t* device_add(int busid, int devid, int vendorid, int deviceid, int type,
                      char *serial, char *shortname, char *longname,
                      char *sysname, struct udev_device *udev);
+void      device_free(device_t *device);
 int       device_del(int  busid, int  devid);
 char*     device_type(unsigned char class, unsigned char subclass,
                       unsigned char protocol);

--- a/src/project.h
+++ b/src/project.h
@@ -173,6 +173,7 @@ xcdbus_conn_t *g_xcbus;      /**< The global dbus (libxcdbus) handle, initialize
 vm_t vms;                    /**< The global list of VMs, handled by vm.c */
 device_t devices;            /**< The global list of devices, handled by device.c */
 struct udev *udev_handle;    /**< The global udev handle, initialized by udev_init() */
+extern int usb_backend_domid;
 
 int   usbowls_plug_device(int domid, int bus, int device);
 int   usbowls_unplug_device(int domid, int bus, int device);
@@ -225,6 +226,10 @@ void  xenstore_get_xb_states(dominfo_t *domp, usbinfo_t *usbp, int *frontst, int
 void  xenstore_list_domain_devs(dominfo_t *domp);
 int   xenstore_init(const int backend_domid);
 void  xenstore_deinit(void);
+void  xenstore_event(void);
+int   xenstore_new_backend(const int backend_domid);
+int   xsdev_watch_init(void);
+void  xsdev_watch_deinit(void);
 
 int   policy_init(void);
 void  policy_add_rule(rule_t *rule);

--- a/src/project.h
+++ b/src/project.h
@@ -175,6 +175,7 @@ device_t devices;            /**< The global list of devices, handled by device.
 struct udev *udev_handle;    /**< The global udev handle, initialized by udev_init() */
 extern int usb_backend_domid;
 
+int   vusb_assign_local(int vendor, int product, int add);
 int   usbowls_plug_device(int domid, int bus, int device);
 int   usbowls_unplug_device(int domid, int bus, int device);
 int   usbowls_build_usbinfo(int bus, int dev, int vendor, int product, usbinfo_t *ui);
@@ -234,6 +235,9 @@ int   xsdev_watch_init(void);
 void  xsdev_watch_deinit(void);
 void  xsdev_write(device_t *dev);
 void  xsdev_del(device_t *dev);
+
+char *xasprintf(const char *fmt, ...);
+extern char *xs_backend_path;
 
 int   policy_init(void);
 void  policy_add_rule(rule_t *rule);

--- a/src/project.h
+++ b/src/project.h
@@ -194,7 +194,7 @@ int   udev_device_tree_match(struct udev_device *dev,
     const char *value,
     int sysattr /* 1 for sysattr, 0 for property*/);
 
-void  libusb_find_more_about_nic(device_t *device);
+int   libusb_find_more_about_nic(int vendorid, int deviceid);
 
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);

--- a/src/project.h
+++ b/src/project.h
@@ -230,6 +230,7 @@ void  xenstore_get_xb_states(dominfo_t *domp, usbinfo_t *usbp, int *frontst, int
 void  xenstore_list_domain_devs(dominfo_t *domp);
 int   xenstore_init(void);
 void  xenstore_deinit(void);
+int   xenstore_state_handle(void);
 void  xenstore_event(void);
 int   xenstore_new_backend(const int backend_domid);
 int   xsdev_watch_init(void);

--- a/src/project.h
+++ b/src/project.h
@@ -230,6 +230,7 @@ void  xenstore_event(void);
 int   xenstore_new_backend(const int backend_domid);
 int   xsdev_watch_init(void);
 void  xsdev_watch_deinit(void);
+void  xsdev_write(device_t *dev);
 
 int   policy_init(void);
 void  policy_add_rule(rule_t *rule);

--- a/src/project.h
+++ b/src/project.h
@@ -199,8 +199,9 @@ int   libusb_find_more_about_nic(int vendorid, int deviceid);
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);
 int       device_is_ambiguous(device_t* device);
-device_t* device_add(int busid, int devid, int vendorid, int deviceid, char* serial,
-                     char *shortname, char *longname, char *sysname, struct udev_device *udev);
+device_t* device_add(int busid, int devid, int vendorid, int deviceid, int type,
+                     char *serial, char *shortname, char *longname,
+                     char *sysname, struct udev_device *udev);
 int       device_del(int  busid, int  devid);
 char*     device_type(unsigned char class, unsigned char subclass,
                       unsigned char protocol);

--- a/src/project.h
+++ b/src/project.h
@@ -226,7 +226,7 @@ char* xenstore_dom_read (unsigned int domid, const char *format, ...);
 int   xenstore_get_dominfo(int domid, dominfo_t *di);
 void  xenstore_get_xb_states(dominfo_t *domp, usbinfo_t *usbp, int *frontst, int *backst);
 void  xenstore_list_domain_devs(dominfo_t *domp);
-int   xenstore_init(const int backend_domid);
+int   xenstore_init(void);
 void  xenstore_deinit(void);
 void  xenstore_event(void);
 int   xenstore_new_backend(const int backend_domid);

--- a/src/project.h
+++ b/src/project.h
@@ -93,6 +93,8 @@
 #define DOM0_UUID   "00000000-0000-0000-0000-000000000000" /**< Dom0's UUID */
 #define UIVM_UUID   "00000000-0000-0000-0000-000000000001" /**< UIVM's UUID */
 #define UIVM_PATH   "/vm/00000000_0000_0000_0000_000000000001" /**< UIVM's xenstore path */
+#define USBVM_UUID   "00000000-0000-0000-0000-000000000003" /**< USBVM's UUID */
+#define USBVM_PATH   "/vm/00000000_0000_0000_0000_000000000003" /**< USBVM's xenstore path */
 
 #define XENMGR      "com.citrix.xenclient.xenmgr" /**< The dbus name of xenmgr */
 #define XENMGR_OBJ  "/"                           /**< The main dbus object of xenmgr */
@@ -219,7 +221,7 @@ char* xenstore_dom_read (unsigned int domid, const char *format, ...);
 int   xenstore_get_dominfo(int domid, dominfo_t *di);
 void  xenstore_get_xb_states(dominfo_t *domp, usbinfo_t *usbp, int *frontst, int *backst);
 void  xenstore_list_domain_devs(dominfo_t *domp);
-int   xenstore_init(void);
+int   xenstore_init(const int backend_domid);
 void  xenstore_deinit(void);
 
 int   policy_init(void);

--- a/src/project.h
+++ b/src/project.h
@@ -197,6 +197,8 @@ int   udev_device_tree_match(struct udev_device *dev,
 
 int   libusb_find_more_about_nic(int vendorid, int deviceid);
 
+int   common_del_device(int busnum, int devnum);
+
 device_t* device_lookup(int busid, int devid);
 device_t* device_lookup_by_attributes(int vendorid, int deviceid, char *serial);
 int       device_is_ambiguous(device_t* device);

--- a/src/udev.c
+++ b/src/udev.c
@@ -534,28 +534,20 @@ udev_node_to_ids(const char *node, int *busid, int *devid)
 }
 
 /**
- * Cleanup xenstore and delete a device after a udev removal event.
+ * Cleanup xenstore and delete a device after removal.
  *
- * @param dev Udev handle of the device
+ * @param busnum of device
+ * @param devnum of device
  *
  * @return 0 on success, 1 if nothing happened, -1 on failure
  */
 int
-udev_del_device(struct udev_device *dev)
+common_del_device(int busnum, int devnum)
 {
-  const char *node;
-  int busnum;
-  int devnum;
   usbinfo_t ui;
   dominfo_t di;
   device_t *device;
   int ret;
-
-  /* Find the bus and device IDs */
-  node = udev_device_get_devnode(dev);
-  if (node == NULL)
-    return -1;
-  udev_node_to_ids(node, &busnum, &devnum);
 
   /* Cleanup xenstore if the device was assigned to a VM */
   device = device_lookup(busnum, devnum);
@@ -577,6 +569,29 @@ udev_del_device(struct udev_device *dev)
     usbmanager_device_removed();
 
   return ret;
+}
+
+/**
+ * Cleanup xenstore and delete a device after a udev removal event.
+ *
+ * @param dev Udev handle of the device
+ *
+ * @return 0 on success, 1 if nothing happened, -1 on failure
+ */
+int
+udev_del_device(struct udev_device *dev)
+{
+  const char *node;
+  int busnum;
+  int devnum;
+
+  /* Find the bus and device IDs */
+  node = udev_device_get_devnode(dev);
+  if (node == NULL)
+    return -1;
+  udev_node_to_ids(node, &busnum, &devnum);
+
+  return common_del_device(busnum, devnum);
 }
 
 /**

--- a/src/udev.c
+++ b/src/udev.c
@@ -521,6 +521,10 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
   if (auto_assign > 0)
     policy_auto_assign_new_device(device);
 
+  if (device) {
+    xsdev_write(device);
+  }
+
   return device;
 }
 

--- a/src/udev.c
+++ b/src/udev.c
@@ -515,11 +515,6 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
                       serial,
                       model, vendor,
                       sysname, dev);
-  if (device == NULL)
-    return NULL;
-
-  if (auto_assign > 0)
-    policy_auto_assign_new_device(device);
 
   if (device) {
     xsdev_write(device);
@@ -656,6 +651,7 @@ udev_event(void)
   struct udev_device *dev;
   const char *action;
   device_t *device;
+  int auto_assign = my_domid == 0;
 
   dev = udev_monitor_receive_device(udev_mon);
   if (dev) {
@@ -675,6 +671,9 @@ udev_event(void)
             device->vendorid,
             device->deviceid,
             device->serial);
+
+        if (auto_assign)
+          policy_auto_assign_new_device(device);
       } else {
         /* This seems to happen when a device is quickly plugged and
          * unplugged. */

--- a/src/udev.c
+++ b/src/udev.c
@@ -370,6 +370,7 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
   const char *value;
   int busnum, devnum;
   int vendorid, deviceid;
+  int type;
   char *serial = NULL;
   char *vendor = NULL;
   char *model;
@@ -503,18 +504,19 @@ udev_maybe_add_device(struct udev_device *dev, int auto_assign)
     strcpy(serial, value);
   }
 
+  /* Find out more about the device by looking at its children */
+  type = udev_find_more(dev, auto_assign);
+  type |= libusb_find_more_about_nic(vendorid, deviceid);
+
   /* Finally add the device */
   device = device_add(busnum, devnum,
                       vendorid, deviceid,
+                      type,
                       serial,
                       model, vendor,
                       sysname, dev);
   if (device == NULL)
     return NULL;
-
-  /* Find out more about the device by looking at its children */
-  device->type = udev_find_more(dev, auto_assign);
-  device->type |= libusb_find_more_about_nic(vendorid, deviceid);
 
   if (auto_assign > 0)
     policy_auto_assign_new_device(device);

--- a/src/usbmanager.c
+++ b/src/usbmanager.c
@@ -41,6 +41,10 @@ void usbmanager_device_added(device_t *device)
 {
   int dev_id;
 
+  if (g_xcbus == NULL) {
+    return;
+  }
+
   dev_id = device_make_id(device->busid, device->devid);
   notify_com_citrix_xenclient_usbdaemon_device_added(g_xcbus,
                                                      USBDAEMON,
@@ -60,6 +64,10 @@ void usbmanager_device_added(device_t *device)
  */
 void usbmanager_device_removed(void)
 {
+  if (g_xcbus == NULL) {
+    return;
+  }
+
   notify_com_citrix_xenclient_usbdaemon_devices_changed(g_xcbus,
 							USBDAEMON,
 							USBDAEMON_OBJ);

--- a/src/usbowls.c
+++ b/src/usbowls.c
@@ -97,6 +97,22 @@ get_usbinfo(int bus, int dev, usbinfo_t *ui)
   struct udev_device *udev_dev;
   char bus_str[16], dev_str[16];
   int vendor, product;
+  device_t *device;
+
+  device = device_lookup(bus, dev);
+  if (device) {
+    int ret;
+
+    vendor = device->vendorid;
+    product = device->deviceid;
+
+    ret = usbowls_build_usbinfo(bus, dev, vendor, product, ui);
+    if (ret == 0) {
+      return ret;
+    }
+  }
+
+  xd_log(LOG_ERR, "%s: device_lookup failed, falling back to udev", __func__);
 
   enumerate = udev_enumerate_new(udev_handle);
   if (!enumerate) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -115,6 +115,12 @@ vm_add(const int domid, const char *uuid)
      Fix this while duplicating the UUID. */
   new_uuid = uuid_copy_and_sanitize(uuid);
 
+  if (domid > 0 && strcmp(new_uuid, USBVM_UUID) == 0) {
+    xd_log(LOG_WARNING, "Changing USB backend from %d to %d", usb_backend_domid,
+           domid);
+    xenstore_new_backend(domid);
+  }
+
   list_for_each(pos, &vms.list) {
     vm = list_entry(pos, vm_t, list);
     if (vm->domid == domid) {

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -285,7 +285,8 @@ xenstore_create_usb(dominfo_t *domp, usbinfo_t *usbp)
     /*
      * Populate frontend device info
      */
-    if (xenstore_set_keyval(trans, fepath, "backend-id", "0"))
+    snprintf(value, sizeof(value), "%d", usb_backend_domid);
+    if (xenstore_set_keyval(trans, fepath, "backend-id", value))
       break;
     snprintf(value, sizeof (value), "%d", usbp->usb_virtid);
     if (xenstore_set_keyval(trans, fepath, "virtual-device", value))

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -230,7 +230,7 @@ xenstore_list_domain_devs(dominfo_t *domp)
   int domid = domp->di_domid;
   unsigned int count, i;
 
-  snprintf(xpath, sizeof(xpath), "/local/domain/0/backend/vusb/%d", domid);
+  snprintf(xpath, sizeof(xpath), "%s/backend/vusb/%d", xs_dom0path, domid);
   devs = xs_directory(xs_handle, XBT_NULL, xpath, &count);
   if (devs) {
     for (i = 0; i < count; ++i) {

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -275,11 +275,11 @@ xenstore_create_usb(dominfo_t *domp, usbinfo_t *usbp)
     /*
      * Make directories for both front and back ends
      */
-    if (xenstore_add_dir(trans, bepath, 0, XS_PERM_NONE, domp->di_domid,
-                         XS_PERM_READ))
+    if (xenstore_add_dir(trans, bepath, usb_backend_domid, XS_PERM_NONE,
+                         domp->di_domid, XS_PERM_READ))
       break;
-    if (xenstore_add_dir(trans, fepath, domp->di_domid, XS_PERM_NONE, 0,
-                         XS_PERM_READ))
+    if (xenstore_add_dir(trans, fepath, domp->di_domid, XS_PERM_NONE,
+                         usb_backend_domid, XS_PERM_READ))
       break;
 
     /*

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -703,6 +703,34 @@ void xsdev_write(device_t *dev)
   free(path);
 }
 
+void xsdev_remove(char *path)
+{
+  int busid;
+  int devid;
+  int num;
+  char *p;
+
+  xd_log(LOG_INFO, "%s path=%s", __func__, path);
+
+  p = strrchr(path, '/');
+  if (p == NULL) {
+    xd_log(LOG_ERR, "could not find '/' in path=%s", path);
+
+    return;
+  }
+  p++;
+
+  num = sscanf(p, "dev%d-%d", &busid, &devid);
+  if (num != 2) {
+    xd_log(LOG_ERR, "%s could not parse path=%s", __func__, path);
+
+    return;
+  }
+
+  xd_log(LOG_INFO, "%s removing dev%d-%d", __func__, busid, devid);
+  common_del_device(busid, devid);
+}
+
 void
 xsdev_event_one(char *path)
 {
@@ -723,7 +751,9 @@ xsdev_event_one(char *path)
 
   dev_path = xs_read(xs_handle, 0, path, &len);
   if (dev_path == NULL) {
-    /* Remove */
+    xsdev_remove(path);
+
+    return;
   }
   free(dev_path);
 

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -602,6 +602,37 @@ xsdev_watch_init(void)
   return xs_fileno(xs_handle);
 }
 
+void xsdev_del(device_t *dev)
+{
+  if (g_xcbus) {
+    return;
+  }
+
+  xd_log(LOG_INFO, "%s %d %d %s", __func__, dev->busid, dev->devid,
+         dev->sysname);
+
+  char *path = xasprintf("data/usb/dev%d-%d", dev->busid, dev->devid);
+  if (path == NULL) {
+    xd_log(LOG_ERR, "%s: xasprintf path failed", __func__);
+    return;
+  }
+
+  char *vusb_watch = xasprintf("%s/assign", path);
+  char *vusb_token = xasprintf("assign:%x %x", dev->vendorid,
+                 dev->deviceid);
+
+  xs_unwatch(xs_handle, vusb_watch, vusb_token);
+
+  free(vusb_watch);
+  free(vusb_token);
+
+  if (xs_rm(xs_handle, XBT_NULL, path) == false) {
+    xd_log(LOG_ERR, "failure xs_rm(%s)", path);
+  }
+
+  free(path);
+}
+
 void xsdev_write(device_t *dev)
 {
   xs_transaction_t t;

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -797,7 +797,7 @@ xsdev_add(char *path)
 
   xs_transaction_t t;
 
-  xd_log(LOG_INFO, "xenstore event %s", path);
+  xd_log(LOG_DEBUG, "xenstore event %s", path);
 
   p = strrchr(path, '/');
   if (p == NULL) {

--- a/src/xenstore.c
+++ b/src/xenstore.c
@@ -847,6 +847,9 @@ xsdev_event_one(char *path)
     xd_log(LOG_INFO, "%s: device %d:%d already added", __func__, busid, devid);
     return;
   }
+
+  /* We always auto-assign when the devices come through XenStore */
+  policy_auto_assign_new_device(dev);
 }
 
 void xsdev_assigning(char *path, char *token)


### PR DESCRIPTION
This adds a second "stub-mode" to vusb-daemon, selected by command line argument.  Regular mode is mostly the same as before with vusb-daemon on dbus and attaching pvUSB devices.  Dom0 can still run this way without a usbvm.  stub-mode is for running in usbvm.

Communication between the dom0 and usbvm vusb-daemon occurs over xenstore.  In stub-mode, vusb-daemon does not connect to dbus.  It writes its USB devices in xenstore under data/usb.  stub-mode has a xenstore watch for device assignment requests, so it can bind the usb device to the backend driver.

When a usbvm is detected, uuid 00000000-0000-0000-0000-000000000003, The dom0 vusbd populates its device list from the xenstore data.  Policy is still enforced in dom0.  dom0 users a xenstore write to instruct the usbvm to bind USB devices, and then does the frontend-backend xenstore writes to set up the PV connection.
