### PR TITLE
Enhancements

### DIFF
--- a/src/policy.h
+++ b/src/policy.h
@@ -37,6 +37,7 @@ enum command {
   ALWAYS,                 /**< Always plug device to VM. implies ALLOW */
   DEFAULT,                /**< Plug device to VM by default, implies ALLOW */
   ALLOW,                  /**< Allow device to be plugged to VM */
+  RUNNING,                /**< Plug device into running VM */
   DENY,                   /**< Deny device to be plugged to VM */
   UNKNOWN                 /**< Unknown command, usually due to input parsing */
 };

--- a/src/project.h
+++ b/src/project.h
@@ -124,6 +124,7 @@ typedef struct {
   struct list_head list; /**< Linux-kernel-style list item */
   int domid;             /**< VM domid */
   char *uuid;            /**< VM UUID */
+  bool emulate;          /**< Use stubdom for emulated passthrough */
 } vm_t;
 
 /**


### PR DESCRIPTION
Two separate enhancements.

The first switches the PV passthrough from the guest to instead passtrough to the stubdom.  openxt-vusb can be installed in the stubdom, and then QEMU emulation can get the device into the guest.

The second expands the policy to allow a new "running" rule.  The use case is you have N VMs, but you only run one at a time.  You want the USB device to get passed through at bootup or hotplug to whichever one VM is running.  The existing rules wouldn't allow that.